### PR TITLE
Add bluebird to supply Promise for node implementations that do not s…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var inquirer = require('bluebird-inquirer');
 var chalk = require('chalk');
 var util = require('util');
 var yargs = require('yargs');
+var Promise = require('bluebird');
 
 var captain = function captain(shipitConfig, options, cb) {
   var shipit;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Tim Kelty",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "~2.9.34",
     "bluebird-inquirer": "0.0.1",
     "chalk": "^1.1.0",
     "lodash": "^3.10.0",


### PR DESCRIPTION
Super thanks for authoring this module!

I added Bluebird to supply promises as I had a an issue on a node .10.x project where native Promises were not available. This is probably a niche fix but some conservative distros might still be on node .10.x...

Again, thank you for the module.
