### PR TITLE
Add a skipConfirm option to skip the deployment confirm prompt 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ gulp shipit --run deploy,myOtherTask
 
 ------
 
+#### options.availableEnvs
+
+`{boolean} [options.skipConfirm]`
+ 
+> set skipConfirm to true to bypass the deployment confirmation prompt
+
+------
+
 #### options.logItems
 
 `{function} [options.logItems(options, shipit)]`

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ gulp shipit --run deploy,myOtherTask
 
 ------
 
-#### options.availableEnvs
+#### options.skipConfirm
 
 `{boolean} [options.skipConfirm]`
  

--- a/index.js
+++ b/index.js
@@ -79,21 +79,27 @@ var captain = function captain(shipitConfig, options, cb) {
 
     var taskStr = chalk.cyan(options.run.join(chalk.white(', ')));
 
-    return inquirer.prompt([{
-      type: 'confirm',
-      name: 'taskConfirm',
-      default: true,
-      message: util.format('Run tasks [%s]', taskStr),
-    }]).then(function(answers) {
-
-      return new Promise(function(resolve, reject) {
-        if (answers.taskConfirm) {
-          return resolve(shipit);
-        }
-
-        return reject('Shipit process aborted.');
+    if ( options.skipConfirm ) {
+      return new Promise(function(resolve) {
+        return resolve(shipit);
       });
-    });
+    } else {
+      return inquirer.prompt([{
+        type: 'confirm',
+        name: 'taskConfirm',
+        default: true,
+        message: util.format('Run tasks [%s]', taskStr),
+      }]).then(function(answers) {
+
+        return new Promise(function(resolve, reject) {
+          if (answers.taskConfirm) {
+            return resolve(shipit);
+          }
+
+          return reject('Shipit process aborted.');
+        });
+      });
+    }
   };
 
   var envPrompt = function envPrompt() {


### PR DESCRIPTION
Added a skipConfirm to optionally skip the confirm prompt prior to deployment. I'm thinking this would be useful for full automated deployments (i.e. on a CI server)
